### PR TITLE
Fix error setting level as warning

### DIFF
--- a/lightsaber/src/main/java/schwarz/it/lightsaber/LightsaberBindingGraphPlugin.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/LightsaberBindingGraphPlugin.kt
@@ -82,7 +82,7 @@ internal enum class ReportType {
 
 private fun String?.toReportType(): ReportType {
     return when (this) {
-        "warn" -> ReportType.Warning
+        "warning" -> ReportType.Warning
         "error" -> ReportType.Error
         "ignore" -> ReportType.Ignore
         null -> ReportType.Error

--- a/lightsaber/src/test/kotlin/schwarz/it/lightsaber/Utils.kt
+++ b/lightsaber/src/test/kotlin/schwarz/it/lightsaber/Utils.kt
@@ -38,7 +38,7 @@ internal fun createOptions(
 private fun ReportType.toOption(): String {
     return when (this) {
         ReportType.Ignore -> "ignore"
-        ReportType.Warning -> "warn"
+        ReportType.Warning -> "warning"
         ReportType.Error -> "error"
     }
 }


### PR DESCRIPTION
We were failing when setting something to `Severity.Warning`