### PR TITLE
Refactor CodePosition

### DIFF
--- a/lightsaber/src/main/java/schwarz/it/lightsaber/Finding.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/Finding.kt
@@ -1,8 +1,14 @@
+@file:Suppress("JAVA_MODULE_DOES_NOT_EXPORT_PACKAGE")
+
 package schwarz.it.lightsaber
 
+import com.sun.tools.javac.model.JavacElements
+import com.sun.tools.javac.tree.JCTree
+import com.sun.tools.javac.util.DiagnosticSource
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.AnnotationValue
 import javax.lang.model.element.Element
+import javax.lang.model.util.Elements
 
 data class Finding(
     val message: String,
@@ -10,11 +16,22 @@ data class Finding(
 )
 
 data class CodePosition(
-    val element: Element,
-    val annotationMirror: AnnotationMirror? = null,
-    val annotationValue: AnnotationValue? = null,
-)
+    val path: String,
+    val line: Int,
+    val column: Int,
+) {
+    override fun toString() = "$path:$line:$column"
+}
 
-internal fun Element.toCodePosition(): CodePosition {
-    return CodePosition(this)
+internal fun Elements.getCodePosition(
+    element: Element,
+    annotationMirror: AnnotationMirror? = null,
+    annotationValue: AnnotationValue? = null,
+): CodePosition {
+    val pair = (this as JavacElements).getTreeAndTopLevel(element, annotationMirror, annotationValue)
+    val sourceFile = (pair.snd as JCTree.JCCompilationUnit).sourcefile
+    val diagnosticSource = DiagnosticSource(sourceFile, null)
+    val line = diagnosticSource.getLineNumber(pair.fst.pos)
+    val column = diagnosticSource.getColumnNumber(pair.fst.pos, true)
+    return CodePosition(sourceFile.name, line, column)
 }

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/checkers/UnusedBindInstance.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/checkers/UnusedBindInstance.kt
@@ -5,9 +5,11 @@ import dagger.spi.model.BindingKind
 import schwarz.it.lightsaber.Finding
 import schwarz.it.lightsaber.domain.FactoryOrBuilder
 import schwarz.it.lightsaber.utils.getComponentFactoriesAndBuilders
+import javax.lang.model.util.Elements
 
 internal fun checkUnusedBindInstance(
     bindingGraph: BindingGraph,
+    elements: Elements,
 ): List<Finding> {
     val usedInstances = bindingGraph.getUsedBindInstances()
 
@@ -17,7 +19,7 @@ internal fun checkUnusedBindInstance(
             val bindInstances = componentNode.getBindInstances()
 
             (bindInstances - usedInstances).map {
-                Finding("The @BindsInstance `$it` is not used.", it.getCodePosition())
+                Finding("The @BindsInstance `$it` is not used.", it.getCodePosition(elements))
             }
         }
 }

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/checkers/UnusedBindsAndProvides.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/checkers/UnusedBindsAndProvides.kt
@@ -6,11 +6,13 @@ import schwarz.it.lightsaber.domain.Module
 import schwarz.it.lightsaber.utils.getDeclaredModules
 import schwarz.it.lightsaber.utils.getUsedModules
 import schwarz.it.lightsaber.utils.toList
+import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
 
 internal fun checkUnusedBindsAndProvides(
     bindingGraph: BindingGraph,
     types: Types,
+    elements: Elements,
 ): List<Finding> {
     val usedBindsAndProvides = bindingGraph.getUsedBindsAndProvides()
     val componentsWithItsDeclaredModules = bindingGraph.getComponentsWithItsDeclaredModules(types)
@@ -21,7 +23,7 @@ internal fun checkUnusedBindsAndProvides(
             .map { module -> module to (module.getBindings() - usedBindsAndProvides) }
             .flatMap { (module, unusedBindings) ->
                 unusedBindings.map { binding ->
-                    Finding("The $binding declared on `$module` is not used.", binding.getCodePosition())
+                    Finding("The $binding declared on `$module` is not used.", binding.getCodePosition(elements))
                 }
             }
     }

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/checkers/UnusedDependencies.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/checkers/UnusedDependencies.kt
@@ -8,12 +8,14 @@ import schwarz.it.lightsaber.utils.fold
 import schwarz.it.lightsaber.utils.getComponentAnnotation
 import schwarz.it.lightsaber.utils.getDependenciesCodePosition
 import schwarz.it.lightsaber.utils.getTypesMirrorsFromClass
+import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
 import kotlin.jvm.optionals.getOrElse
 
 internal fun checkUnusedDependencies(
     bindingGraph: BindingGraph,
     types: Types,
+    elements: Elements,
 ): List<Finding> {
     val used = bindingGraph.getUsedDependencies()
     return bindingGraph.componentNodes()
@@ -21,7 +23,7 @@ internal fun checkUnusedDependencies(
         .flatMap { component ->
             val declared = component.getDeclaredDependencies(types)
             (declared - used).map {
-                Finding("The dependency `$it` is not used.", component.getDependenciesCodePosition())
+                Finding("The dependency `$it` is not used.", component.getDependenciesCodePosition(elements))
             }
         }
 }

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/domain/FactoryOrBuilder.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/domain/FactoryOrBuilder.kt
@@ -3,12 +3,13 @@ package schwarz.it.lightsaber.domain
 import dagger.spi.model.DaggerElement
 import dagger.spi.model.DaggerTypeElement
 import schwarz.it.lightsaber.CodePosition
-import schwarz.it.lightsaber.toCodePosition
+import schwarz.it.lightsaber.getCodePosition
 import schwarz.it.lightsaber.utils.fold
 import schwarz.it.lightsaber.utils.isAnnotatedWith
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
+import javax.lang.model.util.Elements
 
 interface FactoryOrBuilder {
     fun getBindInstance(): List<BindsInstance>
@@ -25,7 +26,7 @@ interface FactoryOrBuilder {
     }
 
     interface BindsInstance {
-        fun getCodePosition(): CodePosition
+        fun getCodePosition(elements: Elements): CodePosition
         override fun toString(): String
 
         companion object {
@@ -51,8 +52,8 @@ private value class FactoryOrBuilderJavac(private val value: Element) : FactoryO
 
     @JvmInline
     value class BindsInstance(private val value: Element) : FactoryOrBuilder.BindsInstance {
-        override fun getCodePosition(): CodePosition {
-            return value.toCodePosition()
+        override fun getCodePosition(elements: Elements): CodePosition {
+            return elements.getCodePosition(value)
         }
 
         override fun toString(): String {

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/utils/BindingGraph.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/utils/BindingGraph.kt
@@ -6,8 +6,10 @@ import dagger.spi.model.BindingGraph
 import schwarz.it.lightsaber.CodePosition
 import schwarz.it.lightsaber.domain.FactoryOrBuilder
 import schwarz.it.lightsaber.domain.Module
+import schwarz.it.lightsaber.getCodePosition
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
+import javax.lang.model.util.Elements
 import kotlin.jvm.optionals.getOrNull
 
 internal fun BindingGraph.getUsedModules(): Set<Module> {
@@ -37,13 +39,13 @@ private fun Element.isCompanionModule(): Boolean {
         simpleName.toString() == "Companion"
 }
 
-internal fun BindingGraph.ComponentNode.getModulesCodePosition(): CodePosition {
+internal fun BindingGraph.ComponentNode.getModulesCodePosition(elements: Elements): CodePosition {
     return componentPath().currentComponent()
         .fold(
             { element ->
                 val annotationMirror = element.findAnnotationMirrors("Component")
                     ?: element.findAnnotationMirrors("Subcomponent")!!
-                CodePosition(
+                elements.getCodePosition(
                     element,
                     annotationMirror,
                     annotationMirror.getAnnotationValue("modules"),
@@ -53,12 +55,12 @@ internal fun BindingGraph.ComponentNode.getModulesCodePosition(): CodePosition {
         )
 }
 
-internal fun BindingGraph.ComponentNode.getDependenciesCodePosition(): CodePosition {
+internal fun BindingGraph.ComponentNode.getDependenciesCodePosition(elements: Elements): CodePosition {
     return componentPath().currentComponent()
         .fold(
             { element ->
                 val annotationMirror = element.findAnnotationMirrors("Component")!!
-                CodePosition(
+                elements.getCodePosition(
                     element,
                     annotationMirror,
                     annotationMirror.getAnnotationValue("dependencies"),


### PR DESCRIPTION
Refactor CodePosition. I see pros and cons to this change:

PROS:
- Simplify `LightsaberBindingGraphPlugin`. In that class we should have as little logic as possible. It should just be glue code.
- CodePosition doesn't know about javac or ksp. It just contain simple values.
- With the current API implement something like #43 was difficult. With this API it should be easier.

CONS:
- We need an instance of `Elements` to get the `CodePosition` on the rules so we are passing this value all round the rules.
- This instance doesn't exist on KSP so we are moving a parameter around in the rules that is only used in only one use case.