### PR TITLE
Use more full qualified names

### DIFF
--- a/lightsaber/src/main/java/schwarz/it/lightsaber/domain/Module.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/domain/Module.kt
@@ -80,7 +80,7 @@ private value class ModuleJavac(private val value: TypeElement) : Module {
     }
 
     override fun getIncludesCodePosition(daggerProcessingEnv: DaggerProcessingEnv): CodePosition {
-        val annotationMirror = value.findAnnotationMirrors("Module")!!
+        val annotationMirror = value.findAnnotationMirrors(dagger.Module::class.qualifiedName!!)!!
         return daggerProcessingEnv.getElements().getCodePosition(
             value,
             annotationMirror,

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/utils/BindingGraph.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/utils/BindingGraph.kt
@@ -53,8 +53,8 @@ internal fun BindingGraph.ComponentNode.getModulesCodePosition(daggerProcessingE
     return componentPath().currentComponent()
         .fold(
             { element ->
-                val annotationMirror = element.findAnnotationMirrors("Component")
-                    ?: element.findAnnotationMirrors("Subcomponent")!!
+                val annotationMirror = element.findAnnotationMirrors(Component::class.qualifiedName!!)
+                    ?: element.findAnnotationMirrors(Subcomponent::class.qualifiedName!!)!!
                 daggerProcessingEnv.getElements().getCodePosition(
                     element,
                     annotationMirror,
@@ -63,7 +63,10 @@ internal fun BindingGraph.ComponentNode.getModulesCodePosition(daggerProcessingE
             },
             { classDeclaration ->
                 classDeclaration.annotations
-                    .single { it.shortName.asString() == "Component" || it.shortName.asString() == "Subcomponent" }
+                    .single {
+                        val annotationQualifiedName = it.annotationType.resolve().declaration.qualifiedName!!.asString()
+                        annotationQualifiedName == Component::class.qualifiedName!! || annotationQualifiedName == Subcomponent::class.qualifiedName!!
+                    }
                     .location
                     .toCodePosition()
             },
@@ -74,7 +77,7 @@ internal fun BindingGraph.ComponentNode.getDependenciesCodePosition(daggerProces
     return componentPath().currentComponent()
         .fold(
             { element ->
-                val annotationMirror = element.findAnnotationMirrors("Component")!!
+                val annotationMirror = element.findAnnotationMirrors(Component::class.qualifiedName!!)!!
                 daggerProcessingEnv.getElements().getCodePosition(
                     element,
                     annotationMirror,
@@ -83,7 +86,7 @@ internal fun BindingGraph.ComponentNode.getDependenciesCodePosition(daggerProces
             },
             { classDeclaration ->
                 classDeclaration.annotations
-                    .single { it.shortName.asString() == "Component" }
+                    .single { it.annotationType.resolve().declaration.qualifiedName!!.asString() == Component::class.qualifiedName!! }
                     .location
                     .toCodePosition()
             },

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/utils/Element.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/utils/Element.kt
@@ -13,9 +13,7 @@ internal fun <T : Annotation> Element.isAnnotatedWith(klass: KClass<T>): Boolean
 }
 
 internal fun TypeElement.findAnnotationMirrors(annotationName: String): AnnotationMirror? {
-    return annotationMirrors.singleOrNull { annotationMirror ->
-        annotationMirror.annotationType.asElement().simpleName.toString() == annotationName
-    }
+    return annotationMirrors.singleOrNull { it.annotationType.toString() == annotationName }
 }
 
 internal fun AnnotationMirror.getAnnotationValue(key: String): AnnotationValue {


### PR DESCRIPTION
They are safer than just the name of the annotation