### PR TITLE
Don't add `.lightsaber` files inside the classpath

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/schwarz/it/lightsaber/gradle/LightsaberPluginIntegrationTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/schwarz/it/lightsaber/gradle/LightsaberPluginIntegrationTest.kt
@@ -63,6 +63,74 @@ class LightsaberPluginIntegrationTest {
     }
 
     @Test
+    fun annotationProcessor_cache() {
+        val runner = GradleRunner.create()
+            .withProjectDirFromResources("annotationProcessor")
+            .withPluginClasspath()
+            .withArguments("lightsaberCheck", "--build-cache")
+
+        runner.buildAndFail()
+
+        runner.projectDir.resolve("build/generated/lightsaber").deleteRecursively()
+
+        val buildResult = runner.buildAndFail()
+
+        assertThat(buildResult).hasTask(":compileJava").hasOutcome(TaskOutcome.FROM_CACHE)
+        assertThat(buildResult).hasTask(":compileTestJava")
+        assertThat(buildResult).hasTask(":lightsaberCheck").hasOutcome(TaskOutcome.FAILED)
+
+        assertThat(buildResult).contains("MyModule.java:15:17: The @Provides `myLong` declared in `com.example.MyModule` is not used. [UnusedBindsAndProvides]")
+        assertThat(buildResult).contains("Foo.java:5:8: The @Inject in `com.example.Foo` constructor is unused because there is a @Provides defined in `com.example.MyModule.foo`. [UnusedInject]")
+        assertThat(buildResult).contains("> Analysis failed with 2 errors")
+        assertThat(buildResult).doesNotContain("warning:")
+    }
+
+    @Test
+    fun kapt_cache() {
+        val runner = GradleRunner.create()
+            .withProjectDirFromResources("kapt")
+            .withPluginClasspath()
+            .withArguments("lightsaberCheck", "--build-cache")
+
+        runner.buildAndFail()
+
+        runner.projectDir.resolve("build/generated/lightsaber").deleteRecursively()
+
+        val buildResult = runner.buildAndFail()
+
+        assertThat(buildResult).hasTask(":kaptKotlin").hasOutcome(TaskOutcome.FROM_CACHE)
+        assertThat(buildResult).hasTask(":kaptTestKotlin")
+        assertThat(buildResult).hasTask(":lightsaberCheck").hasOutcome(TaskOutcome.FAILED)
+
+        assertThat(buildResult).contains("MyModule.java:26:27: The @Provides `myLong` declared in `com.example.MyModule` is not used. [UnusedBindsAndProvides]")
+        assertThat(buildResult).contains("Foo.java:4:14: The @Inject in `com.example.Foo` constructor is unused because there is a @Provides defined in `com.example.MyModule.Companion.provideFoo`. [UnusedInject]")
+        assertThat(buildResult).contains("> Analysis failed with 2 errors")
+        assertThat(buildResult).doesNotContain("warning:")
+    }
+
+    @Test
+    fun ksp_cache() {
+        val runner = GradleRunner.create()
+            .withProjectDirFromResources("ksp")
+            .withPluginClasspath()
+            .withArguments("lightsaberCheck", "--build-cache")
+
+        runner.buildAndFail()
+
+        runner.projectDir.resolve("build/generated/lightsaber").deleteRecursively()
+
+        val buildResult = runner.buildAndFail()
+
+        assertThat(buildResult).hasTask(":kspKotlin").hasOutcome(TaskOutcome.FROM_CACHE)
+        assertThat(buildResult).hasTask(":kspTestKotlin")
+        assertThat(buildResult).hasTask(":lightsaberCheck").hasOutcome(TaskOutcome.FAILED)
+
+        assertThat(buildResult).contains("MyComponent.kt:24: The @Provides `myLong` declared in `com.example.MyModule` is not used. [UnusedBindsAndProvides]")
+        assertThat(buildResult).contains("MyComponent.kt:33: The @Inject in `com.example.Foo` constructor is unused because there is a @Provides defined in `com.example.MyModule.Companion.provideFoo`. [UnusedInject]")
+        assertThat(buildResult).contains("> Analysis failed with 2 errors")
+    }
+
+    @Test
     fun androidAnnotationProcessor() {
         val buildResult = GradleRunner.create()
             .withProjectDirFromResources("androidAnnotationProcessor")

--- a/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/AnnotationProcessor.kt
+++ b/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/AnnotationProcessor.kt
@@ -17,16 +17,27 @@ internal fun Project.registerAnnotationProcessorTask(
     val variantName = variant?.capitalized()
     val lightsaberCheck = registerTask(extension, variantName.orEmpty())
     lightsaberCheck.configure { task ->
+        val lightsaberOutputDir = lightsaberOutputDir("annotationProcessor")
         val taskProvider = provider {
             tasks.withType(JavaCompile::class.java)
                 .matching { it.name.startsWith("compile${variantName.orEmpty()}") }
+                .apply {
+                    configureEach { javacTask ->
+                        val sourceSet = javacTask.name
+                            .removePrefix("kapt")
+                            .removeSuffix("Kotlin")
+                            .ifEmpty { "main" }
+                            .replaceFirstChar { it.lowercaseChar() }
+                        val output = lightsaberOutputDir.map { it.dir(sourceSet) }
+                        javacTask.options.compilerArgumentProviders.add(LightsaberArgumentProvider(output))
+
+                        javacTask.outputs.dir(output)
+                    }
+                }
         }
         task.dependsOn(taskProvider)
 
-        task.source = taskProvider.get()
-            .map { fileTree(it.destinationDirectory.dir("schwarz/it/lightsaber")).asFileTree }
-            .reduce { acc, fileTree -> acc.plus(fileTree) }
-            .matching { it.include("*.lightsaber") }
+        task.source += fileTree(lightsaberOutputDir)
     }
     return lightsaberCheck
 }

--- a/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/AnnotationProcessor.kt
+++ b/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/AnnotationProcessor.kt
@@ -18,12 +18,8 @@ internal fun Project.registerAnnotationProcessorTask(
     val lightsaberCheck = registerTask(extension, variantName.orEmpty())
     lightsaberCheck.configure { task ->
         val taskProvider = provider {
-            if (variantName == null) {
-                tasks.withType(JavaCompile::class.java)
-            } else {
-                tasks.withType(JavaCompile::class.java)
-                    .matching { it.name.startsWith("compile$variantName") }
-            }
+            tasks.withType(JavaCompile::class.java)
+                .matching { it.name.startsWith("compile${variantName.orEmpty()}") }
         }
         task.dependsOn(taskProvider)
 

--- a/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/Kapt.kt
+++ b/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/Kapt.kt
@@ -19,12 +19,8 @@ internal fun Project.registerKaptTask(
     val lightsaberCheck = registerTask(extension, variantName.orEmpty())
     lightsaberCheck.configure { task ->
         val taskProvider = provider {
-            if (variant == null) {
-                tasks.withType(BaseKapt::class.java)
-            } else {
-                tasks.withType(BaseKapt::class.java)
-                    .matching { it.name.startsWith("kapt$variantName") }
-            }
+            tasks.withType(BaseKapt::class.java)
+                .matching { it.name.startsWith("kapt${variantName.orEmpty()}") }
         }
         task.dependsOn(taskProvider)
 

--- a/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/Ksp.kt
+++ b/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/Ksp.kt
@@ -19,12 +19,8 @@ internal fun Project.registerKspTask(
     val lightsaberCheck = registerTask(extension, variantName.orEmpty())
     lightsaberCheck.configure { task ->
         val taskProvider = provider {
-            if (variantName == null) {
-                tasks.withType(KspTaskJvm::class.java)
-            } else {
-                tasks.withType(KspTaskJvm::class.java)
-                    .matching { it.name.startsWith("ksp$variantName") }
-            }
+            tasks.withType(KspTaskJvm::class.java)
+                .matching { it.name.startsWith("ksp${variantName.orEmpty()}") }
         }
         task.dependsOn(taskProvider)
 

--- a/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/Processor.kt
+++ b/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/Processor.kt
@@ -2,6 +2,9 @@ package schwarz.it.lightsaber.gradle.processors
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.process.CommandLineArgumentProvider
 
 enum class Processor { AnnotationProcessor, Kapt, Ksp }
 
@@ -39,3 +42,12 @@ private fun Dependency.isAtLeastVersion(major: Int, minor: Int): Boolean {
 
 private const val MAJOR = 2
 private const val MINOR = 48
+
+internal fun Project.lightsaberOutputDir(tech: String) = layout.buildDirectory.dir("generated/lightsaber/$tech")
+
+internal class LightsaberArgumentProvider(
+    private val outputDir: Provider<Directory>,
+    private val ksp: Boolean = false,
+) : CommandLineArgumentProvider {
+    override fun asArguments() = listOf("${if (ksp) "" else "-A"}Lightsaber.path=${outputDir.get().asFile.path}")
+}

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/LightsaberDaggerProcessor.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/LightsaberDaggerProcessor.kt
@@ -15,6 +15,7 @@ import schwarz.it.lightsaber.checkers.checkUnusedScopes
 import schwarz.it.lightsaber.utils.FileGenerator
 import schwarz.it.lightsaber.utils.getQualifiedName
 import schwarz.it.lightsaber.utils.writeFile
+import kotlin.io.path.Path
 
 @AutoService(BindingGraphPlugin::class)
 public class LightsaberDaggerProcessor : BindingGraphPlugin {
@@ -67,7 +68,8 @@ public class LightsaberDaggerProcessor : BindingGraphPlugin {
             checkUnusedScopes = options["Lightsaber.CheckUnusedScopes"] != "false",
         )
         this.daggerProcessingEnv = processingEnv
-        this.fileGenerator = FileGenerator(processingEnv)
+        val path = checkNotNull(options["Lightsaber.path"]) { "Lightsaber.path argument not provided" }
+        this.fileGenerator = FileGenerator(Path(path))
     }
 
     override fun supportedOptions(): Set<String> {
@@ -79,6 +81,7 @@ public class LightsaberDaggerProcessor : BindingGraphPlugin {
             "Lightsaber.CheckUnusedMembersInjectionMethods",
             "Lightsaber.CheckUnusedModules",
             "Lightsaber.CheckUnusedScopes",
+            "Lightsaber.path",
         )
     }
 }

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/LightsaberJavacProcessor.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/LightsaberJavacProcessor.kt
@@ -9,13 +9,15 @@ import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
+import kotlin.io.path.Path
 
 class LightsaberJavacProcessor : AbstractProcessor() {
     private lateinit var fileGenerator: FileGenerator
     private lateinit var rules: Set<Pair<String, LightsaberJavacRule>>
 
     override fun init(processingEnv: ProcessingEnvironment) {
-        fileGenerator = FileGenerator(processingEnv.filer)
+        val path = checkNotNull(processingEnv.options["Lightsaber.path"]) { "Lightsaber.path argument not provided" }
+        fileGenerator = FileGenerator(Path(path))
         val elements = processingEnv.elementUtils
         rules = buildSet {
             if (processingEnv.options["Lightsaber.CheckUnusedInject"] != "false") {
@@ -46,7 +48,11 @@ class LightsaberJavacProcessor : AbstractProcessor() {
         return false
     }
 
-    override fun getSupportedOptions() = setOf("Lightsaber.CheckUnusedInject", "Lightsaber.CheckUnusedScopes")
+    override fun getSupportedOptions() = setOf(
+        "Lightsaber.CheckUnusedInject",
+        "Lightsaber.CheckUnusedScopes",
+        "Lightsaber.path",
+    )
 
     override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
 

--- a/lightsaber/src/main/java/schwarz/it/lightsaber/LightsaberKspProcessor.kt
+++ b/lightsaber/src/main/java/schwarz/it/lightsaber/LightsaberKspProcessor.kt
@@ -9,6 +9,7 @@ import schwarz.it.lightsaber.checkers.UnusedInjectKsp
 import schwarz.it.lightsaber.checkers.UnusedScopesKsp
 import schwarz.it.lightsaber.utils.FileGenerator
 import schwarz.it.lightsaber.utils.writeFile
+import kotlin.io.path.Path
 
 internal class LightsaberKspProcessor(
     private val fileGenerator: FileGenerator,
@@ -55,7 +56,8 @@ class LightsaberKspProcessorProvider : SymbolProcessorProvider {
             checkUnusedInject = environment.options["Lightsaber.CheckUnusedInject"] != "false",
             checkUnusedScopes = environment.options["Lightsaber.CheckUnusedScopes"] != "false",
         )
-        return LightsaberKspProcessor(FileGenerator(environment.codeGenerator), config)
+        val path = checkNotNull(environment.options["Lightsaber.path"]) { "Lightsaber.path argument not provided" }
+        return LightsaberKspProcessor(FileGenerator(Path(path)), config)
     }
 }
 

--- a/lightsaber/src/test/kotlin/schwarz/it/lightsaber/utils/KotlinCompiler.kt
+++ b/lightsaber/src/test/kotlin/schwarz/it/lightsaber/utils/KotlinCompiler.kt
@@ -11,7 +11,6 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.kspProcessorOptions
-import com.tschuchort.compiletesting.kspSourcesDir
 import com.tschuchort.compiletesting.kspWithCompilation
 import com.tschuchort.compiletesting.symbolProcessorProviders
 import dagger.internal.codegen.ComponentProcessor
@@ -74,7 +73,7 @@ internal class KaptKotlinCompiler(
         compiler.sources = sourceFiles.asList()
         return CompilationResult(
             compiler.compile(),
-            findGeneratedFiles(compiler.classesDir),
+            compiler.workingDir.resolve("lightsaber").listFiles().orEmpty().asList(),
             compiler.kaptStubsDir,
             CompilationResult.Type.Kapt,
         )
@@ -100,7 +99,7 @@ internal class KspKotlinCompiler(
         compiler.sources = sourceFiles.asList()
         return CompilationResult(
             compiler.compile(),
-            findGeneratedFiles(compiler.kspSourcesDir),
+            compiler.workingDir.resolve("lightsaber").listFiles().orEmpty().asList(),
             compiler.workingDir.resolve("sources"),
             CompilationResult.Type.Ksp,
         )
@@ -140,18 +139,12 @@ internal val CompilationResult.Type.extension
         CompilationResult.Type.Ksp -> "kt"
     }
 
-private fun findGeneratedFiles(file: File): List<File> {
-    return file
-        .walkTopDown()
-        .filter { it.isFile }
-        .toList()
-}
-
-private fun getLightsaberArguments(
+private fun KotlinCompilation.getLightsaberArguments(
     vararg rules: Rule,
 ): MutableMap<String, String> {
     return Rule.entries
         .associate { "Lightsaber.Check${it.name}" to (it in rules).toString() }
+        .plus("Lightsaber.path" to workingDir.resolve("lightsaber").absolutePath)
         .toMutableMap()
 }
 


### PR DESCRIPTION
Fixes #288

We don't want to add the `.lightsaber` files inside the classpath. That have a lot of implications and we don't care about that.

For that reason I'm adding `Lightsaber.path` as a parameter for our analyzers so they can write their output there. And our gradle plugin is the one that decides where to save those files.