### PR TITLE
This avoids warning deprecation in the next version of kotlin

### DIFF
--- a/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/Kapt.kt
+++ b/gradle-plugin/src/main/kotlin/schwarz/it/lightsaber/gradle/processors/Kapt.kt
@@ -48,7 +48,7 @@ internal fun Project.configureLightsaberKapt(extension: LightsaberExtension) {
     dependencies.add("kapt", "io.github.schwarzit:lightsaber:$lightsaberVersion")
     extensions.configure(KaptExtension::class.java) {
         it.arguments {
-            extension.getArguments().forEach { (key, value) -> arg(key, value) }
+            extension.getArguments().forEach { (key, value) -> arg(key, value.toString()) }
         }
     }
 }


### PR DESCRIPTION
I was trying to update Kotlin and I found this. Update kotlin is going to be more difficult so I move this to a different PR