### PR TITLE
Remove support for anvil

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ dagger = "2.53"
 junit_jupiter = "5.13.3"
 kctfork = "0.6.0"
 ksp = "2.1.21-2.0.2"
-anvil = "2.5.1"
 
 [libraries]
 android_gradle_plugin = { module = "com.android.tools.build:gradle", version = "8.0.0" }
@@ -22,8 +21,6 @@ ksp_gradle_plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle
 ksp_api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 kotlin_gradle_plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ktlint = { module = "com.pinterest.ktlint:ktlint-cli", version = "1.7.0" }
-anvil_annotations = { module = "com.squareup.anvil:annotations", version.ref = "anvil" }
-anvil_compiler = { module = "com.squareup.anvil:compiler", version.ref = "anvil" }
 
 [plugins]
 kotlin_plugin = { id = "org.jetbrains.kotlin", version.ref = "kotlin" }

--- a/lightsaber/build.gradle.kts
+++ b/lightsaber/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
     testImplementation(libs.truth)
     testImplementation(libs.kctfork.core)
     testImplementation(libs.kctfork.ksp)
-    testImplementation(libs.anvil.annotations)
-    testImplementation(libs.anvil.compiler)
 }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {

--- a/lightsaber/src/test/kotlin/schwarz/it/lightsaber/checkers/UnusedModulesKtTest.kt
+++ b/lightsaber/src/test/kotlin/schwarz/it/lightsaber/checkers/UnusedModulesKtTest.kt
@@ -231,34 +231,6 @@ internal class UnusedModulesKtTest {
     }
 
     @ParameterizedTest
-    @CsvSource("kapt,4,29")
-    fun anvil(
-        @ConvertWith(CompilerArgumentConverter::class) compiler: KotlinCompiler,
-        line: Int,
-        column: Int?,
-    ) {
-        val component = createSource(
-            """
-                package test
-
-                import com.squareup.anvil.annotations.MergeComponent
-                import javax.inject.Singleton
-
-                @MergeComponent(Singleton::class, modules = [MyModule::class])
-                interface MyComponent
-            """.trimIndent(),
-        )
-
-        val compilation = compiler.compile(component, module)
-
-        compilation.assertUnusedModules(
-            message = "The @Module `test.MyModule` is not used.",
-            line = line,
-            column = column,
-        )
-    }
-
-    @ParameterizedTest
     @CsvSource("kapt,3,29", "ksp,5,")
     fun includeModules1(
         @ConvertWith(CompilerArgumentConverter::class) compiler: KotlinCompiler,

--- a/lightsaber/src/test/kotlin/schwarz/it/lightsaber/checkers/UnusedScopesKtTest.kt
+++ b/lightsaber/src/test/kotlin/schwarz/it/lightsaber/checkers/UnusedScopesKtTest.kt
@@ -198,7 +198,7 @@ internal class UnusedScopesKtTest {
     }
 
     @ParameterizedTest
-    @CsvSource("kapt,Component", "kapt,Subcomponent", "kapt,MergeComponent(Singleton::class)", "kapt,MergeSubcomponent(Singleton::class)", "ksp,Component", "ksp,Subcomponent")
+    @CsvSource("kapt,Component", "kapt,Subcomponent", "ksp,Component", "ksp,Subcomponent")
     fun noReportAComponentNorSubcomponent(
         @ConvertWith(CompilerArgumentConverter::class) compiler: KotlinCompiler,
         type: String,
@@ -207,8 +207,6 @@ internal class UnusedScopesKtTest {
             """
                 package test
 
-                import com.squareup.anvil.annotations.MergeComponent
-                import com.squareup.anvil.annotations.MergeSubcomponent
                 import dagger.Component
                 import dagger.Subcomponent
                 import javax.inject.Inject

--- a/lightsaber/src/test/kotlin/schwarz/it/lightsaber/utils/KotlinCompiler.kt
+++ b/lightsaber/src/test/kotlin/schwarz/it/lightsaber/utils/KotlinCompiler.kt
@@ -4,11 +4,8 @@ package schwarz.it.lightsaber.utils
 
 import com.google.common.truth.Truth.assertThat
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
-import com.squareup.anvil.compiler.AnvilCommandLineProcessor
-import com.squareup.anvil.compiler.AnvilComponentRegistrar
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
-import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.kspProcessorOptions
 import com.tschuchort.compiletesting.kspWithCompilation
@@ -38,60 +35,6 @@ internal class KaptKotlinCompiler(
         )
         kaptArgs = getLightsaberArguments(*rules)
         verbose = false
-
-        @Suppress("DEPRECATION")
-        componentRegistrars = listOf(AnvilComponentRegistrar())
-
-        val anvilCommandLineProcessor = AnvilCommandLineProcessor()
-        commandLineProcessors = listOf(anvilCommandLineProcessor)
-
-        pluginOptions += listOf(
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "disable-component-merging",
-                optionValue = "false",
-            ),
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "generate-dagger-factories",
-                optionValue = "false",
-            ),
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "generate-dagger-factories-only",
-                optionValue = "false",
-            ),
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "src-gen-dir",
-                optionValue = File(workingDir, "build/anvil").absolutePath,
-            ),
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "track-source-files",
-                optionValue = "false",
-            ),
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "ir-merges-file",
-                optionValue = "true",
-            ),
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "anvil-cache-dir",
-                optionValue = File(workingDir, "build/anvil-cache").absolutePath,
-            ),
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "gradle-project-dir",
-                optionValue = workingDir.absolutePath,
-            ),
-            PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "gradle-build-dir",
-                optionValue = File(workingDir, "build/anvil-gradle-build").absolutePath,
-            ),
-        )
     }
 
     override fun compile(vararg sourceFiles: SourceFile): CompilationResult {


### PR DESCRIPTION
Anvil is in maintance mode and block us to support kotlin 2.2 so we are dropping its support.